### PR TITLE
be: Bump to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ inputs:
       Region your s3 bucket is in
     default: 'us-east-1'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
node12 is being deprecated

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>