### PR TITLE
Update `"@actions/core` to 1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/actions/download-artifact#readme",
   "dependencies": {
-    "@actions/core": "^1.2.6",
+    "@actions/core": "^1.10.0",
     "@actions/github": "^5.0.0",
     "aws-sdk": "^2.908.0"
   },


### PR DESCRIPTION
To stop using deprecated `set-output` method
